### PR TITLE
CIL-1938 Provision Terms & Conditions "agreed to" time to ACCESS DB.

### DIFF
--- a/Model/CoAccessdbProvisionerTarget.php
+++ b/Model/CoAccessdbProvisionerTarget.php
@@ -424,6 +424,26 @@ class CoAccessdbProvisionerTarget extends CoProvisionerPluginTarget {
         $message['organizationId'] = $accessOrganizationId;
     }
 
+    // CIL-1938 Provision the most recent Terms & Conditions "agreed to" time
+    $latest_agreement_time = 0;
+    foreach($provisioningData['CoTAndCAgreement'] as $tc) {
+      if(!empty($tc['agreement_time'])
+         && !empty($tc['CoTermsAndConditions']['url'])
+         && $tc['CoTermsAndConditions']['status'] == SuspendableStatusEnum::Active) {
+        $agreement_time = strtotime($tc['agreement_time']);
+        if($agreement_time > $latest_agreement_time) {
+          $latest_agreement_time = $agreement_time;
+        }
+      }
+    }
+    if($profileExists) {
+      if($latest_agreement_time != $profile['agreementTime']) {
+        $message['agreementTime'] = $latest_agreement_time;
+      }
+    } else {
+      $message['agreementTime'] = $latest_agreement_time;
+    }
+
     // If no changes are necessary just return true.
     if($profileExists && empty($message)) {
       $msg = "ACCESS DB Provisioner: ";


### PR DESCRIPTION
Copy code from the LDAP provisioner to get the most recent Terms & Conditions agreement time and provision it to the ACCESS central DB via the Allocations API. 

I met with Nathan Tolbert and we agreed the new parameter should be "agreementTime" (camelCase) with a default of '0' indicating that the latest Terms & Conditions have not yet been agreed to.

Nathan said that passing unknown arguments to the API should not cause issues since they should be ignored. I hot-patched https://registry-dev.access-ci.org/ with this new code and verified that provisioning "agreementTime" to the ACCESS central database via the API did not cause any errors.