### PR TITLE
CIL-2056 - Skip CoPerson records without Identifier

### DIFF
--- a/Model/CoAccessdbProvisionerTarget.php
+++ b/Model/CoAccessdbProvisionerTarget.php
@@ -305,6 +305,12 @@ class CoAccessdbProvisionerTarget extends CoProvisionerPluginTarget {
     $identifierType = $coProvisioningTarget['identifier_type'];
     $accessId = null;
     
+    if(empty($provisioningData['Identifier'])) {
+      $msg = "In function syncPerson: provisioningData for CoPerson $coPersonId has no Identifier. Skipping.";
+      $this->log($msg);
+      return true;
+    }
+
     $ids = Hash::extract($provisioningData['Identifier'], '{n}[type='.$identifierType.']');
 
     if(empty($ids)) {


### PR DESCRIPTION
There are a few CoPerson records in https://registry-test.access-ci.org/ that do not have good data associated with them. In particular, the provisioningData array does not have an "Identifier" index which causes the syncPerson function to error out. This in turn causes the AccessdbProvisioner to get stuck. So, check for problematic provisioningData elements and simply log an error message.